### PR TITLE
Bugfix - modified api to validate block, then stop mining, then add b…

### DIFF
--- a/blockchain.py
+++ b/blockchain.py
@@ -102,7 +102,7 @@ class Blockchain():
             return False
 
         # Check Mining Tx height
-        if block.mining_tx.height != self.last_block.mining_tx.height + 1:
+        if block.height != self.last_block.height + 1:
             # Logging
             self.logger.warning('Block failed validation. Mining_tx height incorrect')
             return False


### PR DESCRIPTION
…lock. Should avoid the race condition where mining and receiving new blocks occur at the same time.

In this fashion, if we mine a block at the same time we receive a block, by stopping mining, the received block should create a fork instead of both being added due to multiple thread validation.